### PR TITLE
Address static flags fixme

### DIFF
--- a/bin/dune
+++ b/bin/dune
@@ -3,6 +3,8 @@
 (executable
  (public_name saroupille_website)
  (name main)
- (libraries dream dream-html tezt assets)
- ;; FIXME: Add this only when using static profile
- (flags (:standard -ccopt -static)))
+ (libraries dream dream-html tezt assets))
+
+(env
+ (profile static
+  (flags (:standard -ccopt -static))))


### PR DESCRIPTION
## Summary
- remove hardcoded `-static` link option from main executable
- add an `env` stanza so it only applies when building with the `static` profile

## Testing
- `dune build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741d792f5c8329aa42684f72d7c046