### PR TITLE
Add AGENT instructions

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,7 @@
+# Agent Operating Manual
+
+This repository uses OCaml and dune. The instructions below apply to all files.
+
+- Format all `.ml` and `.mli` files with `ocamlformat` before committing.
+- Use `dune build` to compile the project and `dune runtest` for tests when available.
+- Commit messages must begin with a short summary followed by an empty line and, if needed, additional details.


### PR DESCRIPTION
## Summary
- add root AGENT manual with formatting and testing instructions

## Testing
- `dune build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68741e6161b88329b92378b8e5fced97